### PR TITLE
GCPFactory module logging level setting via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ Set up and run scripts for Google Cloud Platform (GCP).
 
 
 ## Environment Setup
-* Download the key file for the Google Cloud Platform account to be used by the Datalake Definition tool
-* Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to that key file
+* Download the key file for the Google Cloud Platform account to be used by the Datalake Definition tool.
+* Set the *GOOGLE_APPLICATION_CREDENTIALS* environment variable to point to that key file.
+* Set the *DDF_LOG_LEVEL* environment variable to __DEBUG__ to get debug-level log messages from the GCPFactory. 
 
 
 ## Examples

--- a/gcp/gcp.py
+++ b/gcp/gcp.py
@@ -15,7 +15,18 @@ class GCPFactory:
 
     credentials = None
 
-    custom_roles = dict()
+
+    def __init__(self):
+        log_level = os.environ.get('DDF_LOG_LEVEL')
+        if (log_level is not None):
+            if (log_level == 'DEBUG'):
+                self.logger.setLevel(logging.DEBUG)
+            if (log_level == 'WARNING'):
+                self.logger.setLevel(logging.WARNING)
+            if (log_level == 'ERROR'):
+                self.logger.setLevel(logging.ERROR)
+            if (log_level == 'CRITICAL'):
+                self.logger.setLevel(logging.CRITICAL)
 
 
     def __str__(self):


### PR DESCRIPTION
Added environment variable switch for setting the log level in the GCPFactory. Setting DDF_LOG_LEVEL=(DEBUG|WARNING|ERROR|CRITICAL) will affect the log level accordingly; The default level is INFO.